### PR TITLE
Make edition 2018 more strict

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -217,7 +217,7 @@ fn parse_header_line(line_buf: &[u8]) -> Result<MetaData, DecodeError> {
         match state {
             State::End => unreachable!(),
             State::Keyword => match c {
-                b'a'...b'z' | b'0'...b'9' => {
+                b'a'..=b'z' | b'0'..=b'9' => {
                     if keyword_start_idx.is_none() {
                         keyword_start_idx = Some(position);
                     }
@@ -256,7 +256,7 @@ fn parse_header_line(line_buf: &[u8]) -> Result<MetaData, DecodeError> {
                     }
                 },
                 b"size" => match c {
-                    b'0'...b'9' => {
+                    b'0'..=b'9' => {
                         if value_start_idx.is_none() {
                             value_start_idx = Some(position);
                         }
@@ -278,7 +278,7 @@ fn parse_header_line(line_buf: &[u8]) -> Result<MetaData, DecodeError> {
                     }
                 },
                 b"begin" | b"end" => match c {
-                    b'0'...b'9' => {
+                    b'0'..=b'9' => {
                         if value_start_idx.is_none() {
                             value_start_idx = Some(position);
                         }
@@ -305,7 +305,7 @@ fn parse_header_line(line_buf: &[u8]) -> Result<MetaData, DecodeError> {
                     }
                 },
                 b"line" => match c {
-                    b'0'...b'9' => {
+                    b'0'..=b'9' => {
                         if value_start_idx.is_none() {
                             value_start_idx = Some(position);
                         }
@@ -326,7 +326,7 @@ fn parse_header_line(line_buf: &[u8]) -> Result<MetaData, DecodeError> {
                     }
                 },
                 b"part" | b"total" => match c {
-                    b'0'...b'9' => {
+                    b'0'..=b'9' => {
                         if value_start_idx.is_none() {
                             value_start_idx = Some(position);
                         }
@@ -352,7 +352,7 @@ fn parse_header_line(line_buf: &[u8]) -> Result<MetaData, DecodeError> {
                     }
                 },
                 b"crc32" | b"pcrc32" => match c {
-                    b'0'...b'9' | b'A'...b'F' | b'a'...b'f' => {
+                    b'0'..=b'9' | b'A'..=b'F' | b'a'..=b'f' => {
                         if value_start_idx.is_none() {
                             value_start_idx = Some(position);
                         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,3 @@
-// use std::error;
 use std::convert::From;
 use std::fmt;
 use std::io;
@@ -55,7 +54,7 @@ impl From<io::Error> for EncodeError {
 }
 
 impl fmt::Display for DecodeError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             DecodeError::IncompleteData {
                 ref expected_size,
@@ -78,7 +77,7 @@ impl fmt::Display for DecodeError {
 }
 
 impl fmt::Display for EncodeError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             EncodeError::PartNumberMissing => {
                 write!(f, "Multiple parts, but no part number specified.")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,8 @@
+#![deny(missing_docs)]
+#![deny(rust_2018_compatibility)]
+#![deny(rust_2018_idioms)]
+#![deny(warnings)]
+
 //! [yEnc](http://www.yenc.org) is an encoding scheme to include binary files in Usenet messages.
 //!
 //! The `EncodeOptions` and `DecodeOptions` structs are the entry points for encoding and decoding.


### PR DESCRIPTION
Set compiler options to deny edition 2018 idiom violations and edition 2018 compatibility violations.
Fix any violations in the code.