### PR TITLE
Added an override_filename option to the decoder.

### DIFF
--- a/benches/decode.rs
+++ b/benches/decode.rs
@@ -36,7 +36,7 @@ fn decode_stream(c: &mut Criterion) {
             b.iter(|| {
                 let i = input.clone();
                 let mut input_r = std::io::Cursor::new(i);
-                let options = yenc::DecodeOptions::new("/tmp");
+                let options = yenc::DecodeOptions::new("/tmp", None);
                 options.decode_stream(&mut input_r).unwrap();
             });
         })

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -10,6 +10,7 @@ use super::errors::DecodeError;
 #[derive(Debug)]
 pub struct DecodeOptions<P> {
     output_dir: P,
+    override_filename: Option<P>,
 }
 
 #[derive(Default, Debug)]
@@ -31,8 +32,11 @@ where
 {
     /// Construct new DecodeOptions using the specified path as output directory.
     /// The output directory is
-    pub fn new(output_dir: P) -> DecodeOptions<P> {
-        DecodeOptions { output_dir }
+    pub fn new(output_dir: P, override_filename: Option<P>) -> DecodeOptions<P> {
+        DecodeOptions {
+            output_dir,
+            override_filename,
+        }
     }
     /// Decodes the input file in a new output file.
     ///
@@ -78,7 +82,9 @@ where
                 yenc_block_found = true;
                 // parse header line and determine output filename
                 metadata = parse_header_line(&line_buf)?;
-                if let Some(ref name) = metadata.name {
+                if let Some(ref name) = self.override_filename {
+                    output_pathbuf.push(name);
+                } else if let Some(ref name) = metadata.name {
                     output_pathbuf.push(name.trim());
                 }
             }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -55,7 +55,7 @@ fn encode(input_filename: &str) {
 }
 
 fn decode(input_filename: &str, output_directory: &str) -> u32 {
-    let decode_options = yenc::DecodeOptions::new(output_directory);
+    let decode_options = yenc::DecodeOptions::new(output_directory, None);
     match decode_options.decode_file(&input_filename) {
         Err(err) => {
             println!("Error yEnc decoding {}: {}", input_filename, err);

--- a/tests/singlepart.rs
+++ b/tests/singlepart.rs
@@ -26,7 +26,7 @@ fn decode() {
     let tmpdir = temp_dir();
     let mut tmpfile = tmpdir.clone();
     tmpfile.push("testfile.txt");
-    let decode_options = yenc::DecodeOptions::new(tmpdir);
+    let decode_options = yenc::DecodeOptions::new(tmpdir, None);
     decode_options.decode_stream(&mut c).unwrap();
     File::open(&tmpfile)
         .unwrap()


### PR DESCRIPTION
To be able to support yEnc-encoding with obfuscation of the filename, it must be possible to override the filename used when decoding with a given value.

I ran into this issue that, with such obfuscated filenames, my application would decode all the parts into separate files which made the result sort of useless (and at least on Windows would take a huge amount of space due to the data being written after a lot of null data in each file).

This PR adds a simple `override_filename: Option<P>` to the `DecodeOptions` which is used instead of the one parsed from the metadata if it is set to a value other than `None`.